### PR TITLE
Use pre-commit ?

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,9 @@ repos:
     - id: ruff-check
       args: [ --fix, --show-fixes, --exit-non-zero-on-fix ]
     # - id: ruff-format
+
+# Linting hook for stylistic issues in rst doc files.
+- repo: https://github.com/sphinx-contrib/sphinx-lint
+  rev: v1.0.2
+  hooks:
+    - id: sphinx-lint


### PR DESCRIPTION
Instead of running `ruff check` manually, pre-commit is a widely used tool to run a set of checks (linter, formatter, etc., https://pre-commit.com/):

```
pip install pre-commit
pre-commit run -a
```

The config added here runs some default hooks (preventing to merge with some conflicts, adding big files, removing trailing whitespaces etc.), and ruff and sphinx's linter.
There is also a dedicated CI that can automatically fix PRs and update the config when new versions are available (so replacing the Github action running ruff):
https://pre-commit.ci/