### PR TITLE
Add of a doc page on kilonovae and minor updates on doc

### DIFF
--- a/docs/howto/change_rate.ipynb
+++ b/docs/howto/change_rate.ipynb
@@ -39,7 +39,7 @@
    "id": "762b8ffc-8a0a-4662-8166-cd4e4bc7fb26",
    "metadata": {},
    "source": [
-    "here, let's draw a SNIa, specifying a volumetric rate of 3e4 target/yr/Gpc³. \n",
+    "Here, let's draw a SNIa, specifying a volumetric rate of 3e4 target/yr/Gpc³. \n",
     "We draw that for 1 day and between z=[0, 0.1] full sky. "
    ]
   },

--- a/docs/quickstart/quickstart_survey.ipynb
+++ b/docs/quickstart/quickstart_survey.ipynb
@@ -1001,7 +1001,8 @@
     "## Predefined Survey\n",
     "\n",
     "- `ZTF` (GridSurvey)\n",
-    "- `DES` (GridSurvey) | deep-fields"
+    "- `DES` (GridSurvey) | deep-fields\n",
+    "- `LSST` (GridSurvey) | deep-fields"
    ]
   },
   {

--- a/docs/quickstart/quickstart_target.ipynb
+++ b/docs/quickstart/quickstart_target.ipynb
@@ -18,9 +18,11 @@
     "\n",
     "The first two enables you to draw a sample of transients as given by nature. This last one is needed only if you want to get the transient lightcurves (hence, notably, when you create a dataset). \n",
     "\n",
-    "Two sets of transient have already been implemented:\n",
+    "Several transient classes have already been implemented (see \"List of transient classes\" documentation):\n",
     "- SNeIa (based on salt2 or salt3)\n",
-    "- A generic Transient associated to any single sncosmo.TimeSerieSource (see the list [here](https://sncosmo.readthedocs.io/en/stable/source-list.html))"
+    "- A diversity of core-collapse SNe (SNeII, SNeIIb, SNeIIn, SNeIb, SNeIc, SNeIcBL)\n",
+    "- A generic Transient associated to any single sncosmo.TimeSerieSource (see the list [here](https://sncosmo.readthedocs.io/en/stable/source-list.html))\n",
+    "- Kilonovae"
    ]
   },
   {

--- a/docs/transientclasses/kilonovae.ipynb
+++ b/docs/transientclasses/kilonovae.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "adfc9843",
+   "metadata": {},
+   "source": [
+    "# Kilonovae\n",
+    "\n",
+    "In `skysurvey`, kilonovae  are a pre-built class modeled from a spectra model computed using the POSSIS code from Bulla 2019 (2019MNRAS.489.5037B) and converted as spectral time series into `sncosmo`, making kilonovae usable like any other transient type.\n",
+    "\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b5df8ad",
+   "metadata": {},
+   "source": [
+    "The Kilonova Transient is already defined and ready to use: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6ff192ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import skysurvey\n",
+    "\n",
+    "kilonova = skysurvey.Kilonova()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c7e2506",
+   "metadata": {},
+   "source": [
+    "## Template"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a24b7141",
+   "metadata": {},
+   "source": [
+    "The kilonova template is derived from a POSSIS file, converted into a `AngularTimeSeriesSource`, and finally wrapped into an `sncosmo.Model`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4583cee6",
+   "metadata": {},
+   "source": [
+    "The `template` (skysurvey object) is stored here:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6baa74f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<skysurvey.template.Template at 0x10f43d4c0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "kilonova.template"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3acbad6",
+   "metadata": {},
+   "source": [
+    "The default template is a POSSIS file `nsns_nph1.0e+06_mejdyn0.020_mejwind0.130_phi30.txt` from [kilonova_model](https://github.com/mbulla/kilonova_models). This file contains a kilonova spectral model grid that gives the following data:\n",
+    "- `phase`: time since merger in days\n",
+    "- `wave`: wavelengths in Angstrom\n",
+    "- `cos_theta`: cosine of viewing angle\n",
+    "- `flux`:  model spectral flux density in arbitrary units"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc627142",
+   "metadata": {},
+   "source": [
+    "The data are wrapped into an `AngularTimeSeriesSource`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db54eb88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skysurvey.source.angular import AngularTimeSeriesSource\n",
+    "\n",
+    "source = AngularTimeSeriesSource(phase=phase, wave=wave, flux=flux, cos_theta=cos_theta,\n",
+    "                                         name=\"kilonova\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc5399da",
+   "metadata": {},
+   "source": [
+    "You can access the corresponding source directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "a9be334b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AngularTimeSeriesSource 'kilonova' at 0x1347584d0>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "kilonova.template.source"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daa14a6a",
+   "metadata": {},
+   "source": [
+    "This source is then wrapped into the the final `sncosmo.Model` which becomes the `_TEMPLATE` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddb8f72e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sncosmo\n",
+    "\n",
+    "model = sncosmo.Model(source)\n",
+    "\n",
+    "_KILONOVA_MODEL = get_kilonova_model() #get_kilonova_model() returns the model defined before\n",
+    "\n",
+    "# This becomes the attribute stored in the Kilonova class:\n",
+    "_TEMPLATE = _KILONOVA_MODEL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68052ef1",
+   "metadata": {},
+   "source": [
+    "## Rate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09b77d46",
+   "metadata": {},
+   "source": [
+    "The volumetric rate (the number of transient expected per year and per Gpc³) is the rate for binary neutron star mergers inferred from gravitational-wave observations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b496910c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1000.0"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "kilonova.rate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a389d2c",
+   "metadata": {},
+   "source": [
+    "## Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c621e91b",
+   "metadata": {},
+   "source": [
+    "The default model is based on the [modeldag](https://github.com/MickaelRigault/modeldag) package and contains 7 entries. So the generated data will contains at least 7 columns. It is defined by the following parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "f342b8fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'t0': {'func': <bound method Generator.uniform of Generator(PCG64) at 0x13BFA2F80>,\n",
+       "        'kwargs': {'low': 56000, 'high': 56200}},\n",
+       " 'redshift': {'kwargs': {'zmax': 0.2, 'rate': 1000.0}, 'as': 'z'},\n",
+       " 'magabs': {'func': <bound method Generator.normal of Generator(PCG64) at 0x13BFA2F80>,\n",
+       "            'kwargs': {'loc': -18, 'scale': 1}},\n",
+       " 'magobs': {'func': 'magabs_to_magobs',\n",
+       "            'kwargs': {'z': '@z', 'magabs': '@magabs'}},\n",
+       " 'amplitude': {'func': 'magobs_to_amplitude', 'kwargs': {'magobs': '@magobs'}},\n",
+       " 'theta': {'func': <bound method Generator.uniform of Generator(PCG64) at 0x13BFA2F80>,\n",
+       "           'kwargs': {'low': 0.0, 'high': 90.0}},\n",
+       " 'radec': {'func': <function random_radec at 0x13909f6a0>,\n",
+       "           'kwargs': {},\n",
+       "           'as': ['ra', 'dec']}}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "kilonova"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "env312",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add of a short doc page on the Kilonova transient class on "List of transient classes". 
Will be modified in the future to include how to change the default Possis spectral model/the template of the kilonova class.
Minor updates on other doc pages.
